### PR TITLE
Migrated safe role check to use Ruby OpenSSL libraries (#1)

### DIFF
--- a/lib/facter/safe_pp_role.rb
+++ b/lib/facter/safe_pp_role.rb
@@ -1,21 +1,32 @@
 require 'puppet'
+require 'openssl'
 Facter.add(:safe_pp_role) do
   setcode do
     # pick out the custom OID for pp_role, convert `:` to `_` and strip the leading `..` from the capture
-    safe_pp_role = nil
 
-    cert_data = Facter::Core::Execution.exec(
-        "openssl x509 -text < #{Puppet.settings[:certdir]}/#{Puppet.settings[:certname].downcase}.pem"
-    ).to_s.split(/\n/)
-
-    cert_data.each_with_index do |value, index|
-      if value =~ /1.3.6.1.4.1.34380.1.1.13/
-        safe_pp_role = cert_data[index+1].strip.gsub(/::/, '/').gsub(/^../, '')
-
-        break
+    def read_extention(extentions)
+      extentions.each do | element |
+        if element.oid == 'pp_role' or element.oid == '1.3.6.1.4.1.34380.1.1.13'
+          arr = (element.to_s).split(' ')
+          result = arr[2,arr.length].join
+          return result
+        end
       end
+      # element not found
+      return nil
     end
 
+    cert_data = File.open "#{Puppet.settings[:certdir]}/#{Puppet.settings[:certname].downcase}.pem"
+
+    certificate = OpenSSL::X509::Certificate.new cert_data
+
+    result = read_extention(certificate.extensions)
+    if result == nil
+      safe_pp_role = nil
+    else
+      safe_pp_role = result.strip.gsub(/::/, '/').gsub(/^../, '')
+    end
+  
     safe_pp_role
   end
 end


### PR DESCRIPTION
closes #9 

The output from using the Ruby OpenSSL libraries still breaks it out over 2 lines with the '.,' 

If I compact the role over a 1 line string and pass it to your strip and gsub sanitation it now works in both cases. 