### PR TITLE
Change gsub behaviour to fix safe_role presentation issues. (#2)

### DIFF
--- a/lib/facter/safe_pp_role.rb
+++ b/lib/facter/safe_pp_role.rb
@@ -24,7 +24,7 @@ Facter.add(:safe_pp_role) do
     if result == nil
       safe_pp_role = nil
     else
-      safe_pp_role = result.strip.gsub(/::/, '/').gsub(/^../, '')
+      safe_pp_role = result.strip.gsub(/::/, '/').gsub(/[^a-zA-Z\d\/_-]/, '')
     end
   
     safe_pp_role


### PR DESCRIPTION
fixes https://github.com/GeoffWilliams/puppet-safe_roles/issues/12

Change behaviour of the regex. OpenSSL seems to be picking up random characters when reading the pp_role trusted fact.

This implementation changes the gsub behaviour to remove all characters which are not 
* a-z
* A-Z
* 0-9
* /
* _
* - 

I have not personally seen any other characters other than these used before in role names.
@GeoffWilliams your thoughts?

This should hopefully fix any other weird OpenSSL behaviour we are seeing.